### PR TITLE
Sunil taletenlgia

### DIFF
--- a/app/Http/Controllers/UploadController.php
+++ b/app/Http/Controllers/UploadController.php
@@ -72,11 +72,16 @@ class UploadController extends Controller
 		 }
 
          $path = $file->storeAs('files',$fullname,'public_files');
-
          //check here- file is save or not in folder
          if($path==""){
-            $request->session()->flash('error', 'The folder does not have permission to save file');
-            return redirect()->back();  
+            // Everything for owner, read and execute for others
+            if(chmod($dir, 0755)){
+                $path = $file->storeAs('files',$fullname,'public_files');
+            }
+            else{
+                $request->session()->flash('error', 'Unable to upload file. Please try again later.');
+                return redirect()->back(); 
+            } 
          }
 		 
          try{

--- a/app/Http/Controllers/UploadController.php
+++ b/app/Http/Controllers/UploadController.php
@@ -70,11 +70,16 @@ class UploadController extends Controller
             return redirect()->back();	 
 			 
 		 }
-		 
+
+         $path = $file->storeAs('files',$fullname,'public_files');
+
+         //check here- file is save or not in folder
+         if($path==""){
+            $request->session()->flash('error', 'The folder does not have permission to save file');
+            return redirect()->back();  
+         }
 		 
          try{
-            $path = $file->storeAs('files',$fullname,'public_files');
-			
             $upload = new Upload;
             $upload->file_id = $uniquename;
             $upload->file_name = $fullname;


### PR DESCRIPTION
@BrentAllsop  @gautamv16 ,

We have tried to replicate this issue on our local, but not able to reproduce the same issue. We have added a check in the code that if there is a permission issue, the permission will be grated to the folder. In case error comes, the error will be displayed to the user and no record will be entered in the database. We have updated our code and have created the pull request for the same.